### PR TITLE
Generalized ff

### DIFF
--- a/experiments/training.jl
+++ b/experiments/training.jl
@@ -1,0 +1,83 @@
+using Pkg
+Pkg.activate("../")
+
+using Neat
+using Random
+using Statistics
+
+"""
+    train(; pop_size=150, n_generations=100, input_size=2, output_size=1, speciation_threshold=0.3)
+
+Run a full NEAT training loop for the specified number of generations.
+
+# Keyword Arguments
+- `pop_size`: Number of genomes in the population
+- `n_generations`: Number of generations to evolve
+- `input_size`: Number of input nodes per genome
+- `output_size`: Number of output nodes per genome
+- `speciation_threshold`: Compatibility threshold for species assignment
+
+# Returns
+- The final evolved population
+"""
+function train(; pop_size=150, n_generations=100, input_size=2, output_size=1, speciation_threshold=0.3)
+
+    population = initialize_population(pop_size, input_size, output_size)
+
+    for generation in 1:n_generations
+        println("\n=== Generation $generation ===")
+
+        for genome in population
+            genome.fitness = evaluate_fitness(genome)
+        end
+
+        species_list = Vector{Vector{Genome}}()
+        assign_species!(population, species_list; threshold=speciation_threshold)
+
+        for (i, species) in enumerate(species_list)
+            avg_fit = mean(g -> g.fitness, species)
+            println("Species $i: $(length(species)) genomes, average fitness $(round(avg_fit, digits=4))")
+        end
+
+        adjust_fitness!(species_list)
+
+        
+        offspring_counts = compute_offspring_counts(species_list, pop_size)
+        println("Offspring counts: $offspring_counts")
+
+        
+        new_population = Genome[]
+        for (species, count) in zip(species_list, offspring_counts)
+            if isempty(species)
+                continue
+            end
+
+            
+            best = species[argmax([g.fitness for g in species])]
+            push!(new_population, best)
+
+            # Fill remaining slots with crossover + mutation
+            for _ in 2:count
+                parent1 = rand(species)
+                parent2 = rand(species)
+                child = crossover(parent1, parent2)
+                mutate(child)
+                push!(new_population, child)
+            end
+        end
+
+        
+        population = new_population
+
+    end # for each generation
+
+    return population
+end
+
+final_pop = train(pop_size=100, n_generations=50)
+
+println("Doooooooonnnnneeeeee")
+
+idx = argmax(g -> g.fitness, final_pop)
+best = idx
+println("Best fitness: ", best.fitness)

--- a/src/create_genome.jl
+++ b/src/create_genome.jl
@@ -1,54 +1,52 @@
 module CreateGenome
 
 using ..Types
-
-
 export create_genome
-"""
-    create_genome(id, num_inputs, num_outputs) → Genome
 
-Instantiate a `Genome` with an `id` Id, `num_inputs` input nodes and
-`num_outputs` output nodes.  
-Creates two hardcoded connections—from input 1 and input 2 to the first output—
-each with a random weight.
+"""
+    create_genome(id::Int, num_inputs::Int, num_outputs::Int) → Genome
+
+Creates a `Genome` with:
+- The specified number of input nodes
+- The specified number of output nodes
+- Fully connected input-to-output connections with random weights
+
+NO HIDDEN NODES ARE CREATED INITIALLY
 
 # Arguments
-- `id::Int`: Unique genome identifier.
+- `id::Int`: Unique genome ID.
 - `num_inputs::Int`: Number of input nodes.
 - `num_outputs::Int`: Number of output nodes.
 
 # Returns
-A `Genome(id, nodes, connections)` where `nodes` is a `Dict{Int,Node}` of all
-input/output nodes, and `connections` is a `Dict{(Int,Int),Connection}` with
-two initial connections (innovation 1 and 2).
-
-Network Structure:
-
-2 input neurons
-1 output neuron
-
-No hidden layer
+- `Genome`: A new genome with nodes and fully connected input-output links.
 """
-function create_genome(id::Int, num_inputs::Int, num_outputs::Int)
-    nodes = Dict{Int,Node}()
-    connections = Dict{Tuple{Int,Int},Connection}()
+function create_genome(id::Int, num_inputs::Int, num_outputs::Int)::Genome
+    nodes = Dict{Int, Node}()
+    connections = Dict{Tuple{Int, Int}, Connection}()
 
-    # create input nodes
+    # Create input nodes
     for i in 1:num_inputs
         nodes[i] = Node(i, :input)
     end
 
-    # create output nodes
-    for i in 1:num_outputs
-        nid = num_inputs + i
+    # Create output nodes (IDs continue after input nodes)
+    for j in 1:num_outputs
+        nid = num_inputs + j
         nodes[nid] = Node(nid, :output)
     end
 
-    # Connection from input 1 to output 1 and input 2 to output 1
-    connections[(1, num_inputs + 1)] = Connection(1, num_inputs + 1, randn(), true, 1)
-    connections[(2, num_inputs + 1)] = Connection(2, num_inputs + 1, randn(), true, 2)
+    # Fully connect every input to every output with random weights
+    innov = 1  # Innovation numbers start at 1
+    for i in 1:num_inputs
+        for j in 1:num_outputs
+            out_id = num_inputs + j
+            connections[(i, out_id)] = Connection(i, out_id, randn(), true, innov)
+            innov += 1
+        end
+    end
 
     return Genome(id, nodes, connections, 0.0)
 end
 
-end
+end # module

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -32,7 +32,7 @@ function evaluate_fitness(genome::Genome)::Float64
         total_error += (output_value - target)^2  
     end
 
-    return 4.0-total_error # the lower the error, the higher the fitness
+    return -total_error # the lower the error, the higher the fitness
 end
 
 end

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -24,11 +24,15 @@ function evaluate_fitness(genome::Genome)::Float64
     total_error = 0.0
 
     for (x, target) in xor_data
-        output = forward_pass(genome, x) # compute forward_pass
-        total_error += (output - target)^2  # compute error
+        acts = forward_pass(genome, x)
+
+        output_nodes = [n.id for n in values(genome.nodes) if n.nodetype == :output]
+
+        output_value = acts[output_nodes[1]] 
+        total_error += (output_value - target)^2  
     end
 
-    return -total_error # the lower the error, the higher the fitness
+    return 4.0-total_error # the lower the error, the higher the fitness
 end
 
 end

--- a/src/forward_pass.jl
+++ b/src/forward_pass.jl
@@ -20,13 +20,13 @@ function forward_pass(genome::Genome, input::Vector{Float64})::Dict{Int, Float64
     # Determine evaluation order via topological sorting
     sorted_nodes = topological_sort(genome)
 
-    # Identify input nodes
-    input_nodes = [n.id for n in values(genome.nodes) if n.nodetype == :input]
+    # Identify and sort input nodes to align with provided input vector
+    input_nodes = sort([n.id for n in values(genome.nodes) if n.nodetype == :input])
 
     # Prepare activation storage
     activations = Dict{Int, Float64}()
 
-    # Assign provided values to input nodes
+    # Assign provided values to input nodes in sorted order
     for (i, nid) in enumerate(input_nodes)
         activations[nid] = input[i]
     end

--- a/src/forward_pass.jl
+++ b/src/forward_pass.jl
@@ -1,37 +1,115 @@
 module ForwardPass
 
 using ..Types
-using ..CreateGenome
 
 export forward_pass
 
 """
-    forward_pass(genome::Genome, input::Vector{Float64}) → Float64
+    forward_pass(genome::Genome, input::Vector{Float64}) → Dict{Int, Float64}
 
-Compute the output of a simple feedforward network defined by `genome`.  
-Assumes a hardcoded structure where each input node `i` may connect to output node ID `3`.  
-For each enabled connection `(i, 3)`, multiplies `input[i]` by the connection’s weight and sums
-the results. Applies a sigmoid activation to the final sum.
+Performs a forward pass through the network defined by `genome`, computing activation values for all nodes.
 
 # Arguments
-- `genome::Genome`: The genome containing connection definitions and weights.
-- `input::Vector{Float64}`: A vector of input values; its length should match the number of input nodes.
+- `genome::Genome`: The genome containing nodes and connections.
+- `input::Vector{Float64}`: Activation values for input nodes.
 
 # Returns
-- `Float64`: The sigmoid-activated output of the network (between 0 and 1).
+- `Dict{Int, Float64}`: A dictionary mapping each node ID to its activation value.
 """
-function forward_pass(genome::Genome, input::Vector{Float64})::Float64
-    output_sum = 0.0
-    for i in 1:length(input)
-        conn_key = (i, 3) # assuming output node is always 3 (see first cell; hardcoded)
-        if haskey(genome.connections, conn_key) # if there is edge from i to 3 (op) 
-            conn = genome.connections[conn_key]
-            if conn.enabled # and if connection is enabled
-                output_sum += input[i] * conn.weight # add input*weight to output
+function forward_pass(genome::Genome, input::Vector{Float64})::Dict{Int, Float64}
+    # Determine evaluation order via topological sorting
+    sorted_nodes = topological_sort(genome)
+
+    # Identify input nodes
+    input_nodes = [n.id for n in values(genome.nodes) if n.nodetype == :input]
+
+    # Prepare activation storage
+    activations = Dict{Int, Float64}()
+
+    # Assign provided values to input nodes
+    for (i, nid) in enumerate(input_nodes)
+        activations[nid] = input[i]
+    end
+
+    # Gather enabled connections
+    enabled_conns = [c for c in values(genome.connections) if c.enabled]
+
+    # Compute activations for non-input nodes
+    for node in sorted_nodes
+        # Skip input nodes—they already have values
+        if genome.nodes[node].nodetype == :input
+            continue
+        end
+
+        # Sum weighted inputs
+        sum_input = 0.0
+        for conn in enabled_conns
+            if conn.out_node == node
+                sum_input += activations[conn.in_node] * conn.weight
+            end
+        end
+
+        # Apply sigmoid activation function
+        activations[node] = 1.0 / (1.0 + exp(-sum_input))
+    end
+
+    return activations
+end
+
+"""
+    topological_sort(genome::Genome) → Vector{Int}
+
+Performs a topological sort of all nodes in the `genome`.
+The resulting order ensures each node appears only after all its predecessors have been processed.
+
+# Arguments
+- `genome::Genome`: The genome containing nodes and connections.
+
+# Returns
+- `Vector{Int}`: A list of node IDs in a valid computation order.
+
+# Errors
+- Throws an error if the graph contains cycles, making topological sorting impossible.
+"""
+function topological_sort(genome::Genome)::Vector{Int}
+    # All node IDs
+    nodes = collect(keys(genome.nodes))
+    # Only consider enabled connections
+    enabled_conns = [c for c in values(genome.connections) if c.enabled]
+
+    # 1) Count in-degrees for each node
+    in_degree = Dict(n => 0 for n in nodes)
+    for conn in enabled_conns
+        in_degree[conn.out_node] += 1
+    end
+
+    # 2) Initialize list of nodes with zero in-degree
+    no_incoming = [n for n in nodes if in_degree[n] == 0]
+    order = Int[]  # Sorted order container
+
+    # Kahn's algorithm for topological sort
+    while !isempty(no_incoming)
+        n = popfirst!(no_incoming)
+        push!(order, n)
+
+        # Remove outgoing edges from n
+        for conn in enabled_conns
+            if conn.in_node == n
+                out = conn.out_node
+                in_degree[out] -= 1
+                if in_degree[out] == 0
+                    push!(no_incoming, out)
+                end
             end
         end
     end
-    return 1.0 / (1.0 + exp(-output_sum)) # apply sigmoid
+
+    # 3) If not all nodes are processed, a cycle exists
+    if length(order) != length(nodes)
+        error("Graph contains cycles! Topological sort not possible.")
+    end
+
+    return order
 end
 
-end
+end # module ForwardPass

--- a/src/mutation.jl
+++ b/src/mutation.jl
@@ -58,6 +58,24 @@ function add_connection!(genome::Genome)
             continue
         end
 
+        # Output cannot feed into input or other nodes
+        if in_node.nodetype == :output
+            attempts += 1
+            continue
+        end
+
+        # Do not allow connections INTO input nodes
+        if out_node.nodetype == :input
+            attempts += 1
+            continue
+        end
+
+        # Enforce feedforward order: in_node must come before out_node
+        if in_node.id > out_node.id
+            attempts += 1
+            continue
+        end
+
         if in_node.nodetype == :output && out_node.nodetype == :input  #connection between output -> inout node
             attempts += 1
             continue

--- a/test/create_genome_test.jl
+++ b/test/create_genome_test.jl
@@ -2,32 +2,36 @@ using Test
 using Neat
 
 @testset "create_genome" begin
-    genome = create_genome(1, 2, 1)
+    # Example: 2 inputs, 1 output
+    genome = Neat.CreateGenome.create_genome(1, 2, 1)
 
-    # --- Check basic genome structure ---
-    @test isa(genome, Genome)
+    # --- Check genome type and ID ---
+    @test isa(genome, Neat.Types.Genome)
     @test genome.id == 1
+
+    # --- Check node count ---
     @test length(genome.nodes) == 3  # 2 inputs + 1 output
-    @test length(genome.connections) == 2
+
+    # --- Check connection count (should be inputs * outputs) ---
+    @test length(genome.connections) == 2  # 2 * 1 = 2
 
     # --- Check node types ---
     @test genome.nodes[1].nodetype == :input
     @test genome.nodes[2].nodetype == :input
     @test genome.nodes[3].nodetype == :output
 
-    # --- Check connections ---
-    @test haskey(genome.connections, (1, 3))
-    @test haskey(genome.connections, (2, 3))
+    # --- Check that each input connects to each output ---
+    for input_id in 1:2
+        for output_id in 3:3  # output IDs start at num_inputs + 1
+            @test haskey(genome.connections, (input_id, output_id))
+            conn = genome.connections[(input_id, output_id)]
+            @test conn.enabled == true
+            @test conn.in_node == input_id
+            @test conn.out_node == output_id
+        end
+    end
 
-    conn1 = genome.connections[(1, 3)]
-    conn2 = genome.connections[(2, 3)]
-
-    @test conn1.enabled == true
-    @test conn2.enabled == true
-
-    @test conn1.in_node == 1 && conn1.out_node == 3
-    @test conn2.in_node == 2 && conn2.out_node == 3
-
-    @test conn1.innovation_number == 1
-    @test conn2.innovation_number == 2
+    # --- Check innovation numbers are unique and sequential ---
+    innov_numbers = [conn.innovation_number for conn in values(genome.connections)]
+    @test innov_numbers == collect(1:length(innov_numbers))
 end

--- a/test/forward_pass_test.jl
+++ b/test/forward_pass_test.jl
@@ -1,21 +1,37 @@
 using Test
-using Neat 
+using Neat
 
 @testset "forward_pass" begin
-    # Define dummy nodes and connections
-    nodes = Dict(1 => Node(1, :input), 2 => Node(2, :input), 3 => Node(3, :output))
-
-    connections = Dict(
-        (1, 3) => Connection(1, 3, 0.5, true, 1), (2, 3) => Connection(2, 3, -1.0, true, 2)
+    # --- Create dummy nodes ---
+    nodes = Dict(
+        1 => Neat.Types.Node(1, :input),
+        2 => Neat.Types.Node(2, :input),
+        3 => Neat.Types.Node(3, :output)
     )
 
-    genome = Genome(1, nodes, connections, 0.0)
+    # --- Create dummy connections ---
+    connections = Dict(
+        (1, 3) => Neat.Types.Connection(1, 3, 0.5, true, 1),
+        (2, 3) => Neat.Types.Connection(2, 3, -1.0, true, 2)
+    )
+
+    # --- Create genome ---
+    genome = Neat.Types.Genome(1, nodes, connections, 0.0)
+
+    # --- Input vector ---
     input = [1.0, 2.0]
 
-    output = forward_pass(genome, input)
+    # --- Run forward_pass ---
+    activations = Neat.ForwardPass.forward_pass(genome, input)
 
+    # --- Compute expected output ---
     expected_sum = 1.0 * 0.5 + 2.0 * -1.0  # = -1.5
     expected_output = 1.0 / (1.0 + exp(-expected_sum))  # sigmoid(-1.5)
 
-    @test isapprox(output, expected_output; atol=1e-6)
+    # --- Extract actual output node activation ---
+    output_nodes = [n.id for n in values(nodes) if n.nodetype == :output]
+    @test length(output_nodes) == 1  # ensure only one output
+    output_value = activations[output_nodes[1]]
+
+    @test isapprox(output_value, expected_output; atol=1e-6)
 end


### PR DESCRIPTION
Added generalized feed forward. To obtain this we need to make sure mutations can only happen when in_node.id is lower than out_node.id when adding new connections. This ensures that we dont have have circles in the ff-operation. 
Also we need to make sure to sort the nodes that are used for the feedforward are in a topological order so no node is calculated if not all of the predecessors are calculated. No circular calculations are allowed in this current implementation. To order topographically we are now using Kahns algorithm which sorts the nodes that are visited for computation in such a way, that we never compute a node without its predecessors.  